### PR TITLE
Connection should be done before writer creation

### DIFF
--- a/src/main/java/HiveStreamWriteThread.java
+++ b/src/main/java/HiveStreamWriteThread.java
@@ -42,9 +42,9 @@ public class HiveStreamWriteThread extends Thread {
 
         try {
             Date startDate = new Date();
-            writer = new DelimitedInputWriter(columnFields, ",", endPt);
             connection = endPt.newConnection(false);
-
+            writer = new DelimitedInputWriter(columnFields, ",", endPt);
+            
             int currentBatchSize = maxBatchSize;
 
             TransactionBatch txnBatch = connection.fetchTransactionBatch(maxBatchGroups, writer);


### PR DESCRIPTION
If using partitioned table, the writer constructor tries to check if the partition exists on it's creation, so if there is no connection this will throw an exception